### PR TITLE
Use full wikilink's title as a person's identifier

### DIFF
--- a/action.php
+++ b/action.php
@@ -22,6 +22,7 @@ class action_plugin_orgchart extends DokuWiki_Action_Plugin {
     // register hook
     function register(Doku_Event_Handler $controller) {
         $controller->register_hook('TPL_METAHEADER_OUTPUT','BEFORE', $this, '_addJavascript');
+        $controller->register_hook('DOKUWIKI_STARTED', 'AFTER',  $this, '_addconf');
     }
 
     /**
@@ -40,6 +41,22 @@ class action_plugin_orgchart extends DokuWiki_Action_Plugin {
             'charset' => 'utf-8',
             '_data'   => 'google.load("visualization", "1", {packages:["orgchart"]});'
         );
+    }
+
+    /**
+     * Add plugin's config to script
+     *
+     * @param unknown_type $event
+     * @param unknown_type $param
+     */
+    function _addconf(&$event, $param) {
+        global $JSINFO;
+        $JSINFO['plugin_orgchart_conf'] = array();
+
+        $config_keys = array('useFullId');
+        foreach($config_keys as $key) {
+            $JSINFO['plugin_orgchart_conf'][$key] = $this->getConf($key);
+        }
     }
 
 }

--- a/conf/default.php
+++ b/conf/default.php
@@ -1,0 +1,3 @@
+<?php
+
+$conf['useFullId'] = 0;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -1,0 +1,3 @@
+<?php
+
+$meta['useFullId'] = array('onoff');

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1,0 +1,3 @@
+<?php
+
+$lang['useFullId'] = "Use full wikilink's title as a person's identifier.";

--- a/script.js
+++ b/script.js
@@ -1,6 +1,10 @@
 jQuery(document).ready(function() {
 
     function getStaffId(id) {
+        if (JSINFO['plugin_orgchart_conf']['useFullId'] === 1) {
+            return id;
+        }
+
         var sep_char_index = id.lastIndexOf(':');
         if (sep_char_index !== -1) {
             return id.substring(id.length, sep_char_index+1);


### PR DESCRIPTION
This commit adds a configuration option that is very useful when you want to mix orgchart links from several namespaces.